### PR TITLE
Fix/gauntlet allow duplicates

### DIFF
--- a/src/api/GauntletTools.ts
+++ b/src/api/GauntletTools.ts
@@ -312,10 +312,8 @@ export function gauntletCrewSelection(
 			skills: {}
 		};
 
-		let crw :any = crew;
-
 		for (let skill in CONFIG.SKILLS) {
-			newCrew.skills[skill] = crw[skill].min + crw[skill].max;
+			newCrew.skills[skill] = crew.skills[skill].min + crew.skills[skill].max;
 		}
 
 		newCrew.skills[currentGauntlet.contest_data.featured_skill] =

--- a/src/components/GauntletHelper.tsx
+++ b/src/components/GauntletHelper.tsx
@@ -714,7 +714,7 @@ const GauntletSelectCrew = (props: {
 
 				<div className="two column row">
 					<div className="column">
-						<SpinButton value='{this.state.featuredSkillBonus}' label='Featured skill bonus:' min={0} max={100} step={1}
+						<SpinButton value={String(featuredSkillBonus)} label='Featured skill bonus:' min={0} max={100} step={1}
 							onIncrement={(value) => { setFeaturedSkillBonus(+value + 1); }}
 							onDecrement={(value) => { setFeaturedSkillBonus(+value - 1); }}
 							onValidate={(value: string) => {
@@ -734,7 +734,7 @@ const GauntletSelectCrew = (props: {
 
 				<div className="two column row">
 					<div className="column">
-						<SpinButton value='{this.state.critBonusDivider}' label='Crit bonus divider:' min={0.1} max={100} step={0.1}
+						<SpinButton value={String(critBonusDivider)} label='Crit bonus divider:' min={0.1} max={100} step={0.1}
 							onIncrement={(value) => { setCritBonusDivider(+value + 0.1); }}
 							onDecrement={(value) => { setCritBonusDivider(+value - 0.1); }}
 							onValidate={(value: string) => {

--- a/src/components/GauntletHelper.tsx
+++ b/src/components/GauntletHelper.tsx
@@ -592,7 +592,7 @@ export class GauntletHelper extends React.Component<GauntletHelperProps, Gauntle
 
 					<div style={{ display: 'grid', gridGap: '10px', margin: '8px', gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))' }}>
 						{matches.map((match) =>
-							<GauntletMatch key={match.crewOdd.archetype_symbol + match.opponent.player_id}
+							<GauntletMatch key={match.crewOdd.crew_id + '_' + match.opponent.player_id}
 								match={match}
 								gauntlet={gaunt}
 								consecutive_wins={consecutiveWins}
@@ -647,7 +647,7 @@ const GauntletSelectCrew = (props: {
 			}
 
 			let crewSpan = <Persona
-				key={crew.name}
+				key={crew.crew_id}
 				imageUrl={crew.iconUrl}
 				text={crew.name}
 				secondaryText={crew.short_name}
@@ -688,7 +688,7 @@ const GauntletSelectCrew = (props: {
 					return;
 				}
 
-				crew_ids.push(crew.id);
+				crew_ids.push(crew.crew_id);
 			});
 
 			if (crew_ids.length === 5) {

--- a/webpack/template.html
+++ b/webpack/template.html
@@ -7,8 +7,8 @@
   <link id="themeCSS" rel="stylesheet" href="" />
 
   <script>
-    const g_defaultTheme = '/css/semantic.css';
-    const g_darkTheme = '/css/semantic.slate.css';
+    const g_defaultTheme = './css/semantic.css';
+    const g_darkTheme = './css/semantic.slate.css';
 
     function swapThemeCss() {
       let sheet = document.querySelector('#themeCSS');


### PR DESCRIPTION
This are some fixes to make the gauntlet-page work for me:
- the first commit fixes the calculation form (before the input-fields simply displayed "{this.state.featuredSkillBonus}" as literal text). Also the skills of the crew-members were searched at the wrong place
- the second commit allows to have duplicate crew-members in a gauntlet. The crew-calculation often recommends that I bring both copies of "Armus" I own into the gauntlet, however running the gauntlet did then not work properly, because they were identified by name or archetype-id, which is the same for both. This commit uses the individual crew_id for identification
- the last commit fixes the urls for the theme. This has nothing to do with the gauntlet, however it is a small change, and without it, the theme was not found after packaging the tool (it worked only when using "npm run dev")
