### PR TITLE
Overhaul Voyage tab

### DIFF
--- a/src/assets/css/App.css
+++ b/src/assets/css/App.css
@@ -166,6 +166,10 @@
     align-self: center;
 }
 
+.ui.header.vle-text {
+    margin-top: 0;
+}
+
 .recipe-item-span {
     float: left;
     margin-right: 5px;

--- a/src/assets/css/App.css
+++ b/src/assets/css/App.css
@@ -24,6 +24,10 @@
     object-fit: contain;
 }
 
+.collapsible-section {
+    margin-bottom: 20px;
+}
+
 .ui.label.big.group-header {
     display: inherit;
     text-align: center;
@@ -67,6 +71,11 @@
 .voyage-crew {
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
+}
+
+.voyage-crew .vc-complement,
+.voyage-crew .vc-skills {
     margin-bottom: 20px;
 }
 
@@ -101,6 +110,31 @@
 .voyage-rewards {
     max-width: 750px;
     margin-bottom: 20px;
+}
+
+.voyage-log {
+    border-left: solid 1px;
+    padding-left: 10px;
+    margin-bottom: 20px;
+    margin-left: 10px;
+}
+
+.voyage-log-entry {
+    display: grid;
+    grid-template-rows: auto;
+    grid-template-columns: auto 1fr;
+    column-gap: 10px;
+    min-height: 35px;
+}
+
+.vle-images {
+    justify-self: end;
+    align-self: center;
+}
+
+.vle-text {
+    justify-self: start;
+    align-self: center;
 }
 
 .recipe-item-span {

--- a/src/assets/css/App.css
+++ b/src/assets/css/App.css
@@ -11,7 +11,7 @@
 }
 
 .ship-dropdown {
-    min-width: 25em !important;
+    min-width: 26em !important;
 }
 
 .sprite-dark {
@@ -38,6 +38,35 @@
 .voyage-failed {
     font-size: large;
     color: red;
+}
+
+.voyage-skillsets {
+    display: grid;
+    grid-template-rows: 36px;
+    grid-template-columns: auto 36px auto 36px 1fr;
+    align-items: center;
+    column-gap: 10px;
+    margin-top: 4px;
+    margin-bottom: 16px;
+    font-size: 1.5em;
+}
+
+.voyage-skillsets img {
+    width: 36px;
+    height: 36px;
+}
+
+.voyage-skillsets div:nth-child(3) {
+    margin-left: 20px;
+}
+
+.voyage-crew-select {
+    margin-top: 20px;
+}
+
+.voyage-crew-select .vc-skills {
+    margin-top: 20px;
+    width: fit-content;
 }
 
 .voyage-stats {
@@ -93,13 +122,13 @@
 
 .voyage-crew .vc-complement .vc-position .vcp-crewname,
 .voyage-crew .vc-complement .vc-position .vcp-name,
-.voyage-crew .vc-skills .vc-skill .vcs-range,
-.voyage-crew .vc-skills .vc-skill .vcs-success,
-.voyage-crew .vc-skills .vc-skill .vcs-failure  {
+.vc-skills .vc-skill .vcs-range,
+.vc-skills .vc-skill .vcs-success,
+.vc-skills .vc-skill .vcs-failure  {
     align-self: center;
 }
 
-.voyage-crew .vc-skills .vc-skill {
+.vc-skills .vc-skill {
     display: grid;
     grid-template-rows: 68px;
     grid-template-columns: 68px 1fr 60px 1fr;

--- a/src/assets/css/App.css
+++ b/src/assets/css/App.css
@@ -14,6 +14,95 @@
     min-width: 25em !important;
 }
 
+.sprite-dark {
+    background-color: #1B1C1D;
+}
+
+.image-fit {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+}
+
+.ui.label.big.group-header {
+    display: inherit;
+    text-align: center;
+    margin-bottom: 4px;
+    border-radius: 40px 40px 0 0;
+}
+
+.voyage-failed {
+    font-size: large;
+    color: red;
+}
+
+.voyage-stats {
+    margin-bottom: 20px;
+}
+
+.voyage-stats div {
+    margin-bottom: 4px;
+}
+
+.voyage-stats .overview div {
+    margin-right: 20px;
+}
+
+.voyage-stats .dilemma div {
+    margin-right: 20px;
+}
+
+.voyage-stats .times div {
+    margin-right: 20px;
+}
+
+.voyage-stats .recall div {
+    margin-right: 20px;
+}
+
+.voyage-dilemma {
+    margin-bottom: 20px;
+}
+
+.voyage-crew {
+    display: flex;
+    flex-direction: row;
+    margin-bottom: 20px;
+}
+
+.voyage-crew .vc-complement {
+    margin-right: 40px;
+}
+
+.voyage-crew .vc-complement .vc-position {
+    display: grid;
+    grid-template-rows: 36px;
+    grid-template-columns: 36px 1fr 36px 1fr;
+    column-gap: 10px;
+    margin-bottom: 4px;
+}
+
+.voyage-crew .vc-complement .vc-position .vcp-crewname,
+.voyage-crew .vc-complement .vc-position .vcp-name,
+.voyage-crew .vc-skills .vc-skill .vcs-range,
+.voyage-crew .vc-skills .vc-skill .vcs-success,
+.voyage-crew .vc-skills .vc-skill .vcs-failure  {
+    align-self: center;
+}
+
+.voyage-crew .vc-skills .vc-skill {
+    display: grid;
+    grid-template-rows: 68px;
+    grid-template-columns: 68px 1fr 60px 1fr;
+    column-gap: 28px;
+    margin-bottom: 10px;
+}
+
+.voyage-rewards {
+    max-width: 750px;
+    margin-bottom: 20px;
+}
+
 .recipe-item-span {
     float: left;
     margin-right: 5px;
@@ -122,7 +211,7 @@
     max-height: calc(100vh - 50px);
     overflow-x: hidden;
     overflow-y: auto;
-    padding: 5px 0;
+    padding: 10px;
     position: relative;
 }
 

--- a/src/components/AppHome.tsx
+++ b/src/components/AppHome.tsx
@@ -35,6 +35,7 @@ import { EventHelperPage } from './events/EventHelperPage';
 import { Experiments } from './Experiments';
 import { ModalNotification } from './ModalNotification';
 import { loadUITheme } from './Styles';
+import DarkThemeContext, { DarkThemeProvider } from './DarkThemeContext';
 
 import STTApi from '../api';
 import { loginSequence } from '../api';
@@ -189,6 +190,7 @@ export class AppHome extends React.Component<AppHomeProps, AppHomeState> {
 		}
 
 		return (
+			<DarkThemeProvider value={this.state.darkTheme}>
 			<Fabric style={{ color: this.state.theme.semanticColors.bodyText, backgroundColor: this.state.theme.semanticColors.bodyBackground }} className='App'>
 				<div style={{ display: 'flex', flexFlow: 'column', height: '100%', padding: '3px' }}>
 					<div style={{ flex: '1 1 auto' }}>
@@ -250,6 +252,7 @@ export class AppHome extends React.Component<AppHomeProps, AppHomeState> {
 
 				<ModalNotification ref='modalNotification' />
 			</Fabric>
+			</DarkThemeProvider>
 		);
 	}
 

--- a/src/components/DarkThemeContext.ts
+++ b/src/components/DarkThemeContext.ts
@@ -1,0 +1,12 @@
+import React, { useContext } from 'react';
+
+const DarkThemeContext = React.createContext(false);
+
+export const DarkThemeProvider = DarkThemeContext.Provider;
+
+export const GetSpriteCssClass = () => {
+    const isDarkTheme = useContext(DarkThemeContext);
+    return isDarkTheme ? 'sprite-light' : 'sprite-dark';
+}
+
+export default DarkThemeContext;

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -98,27 +98,27 @@ export const HomePage = (props: {
 			<div className='ui right aligned inverted segment'>
 				<div className='ui black large image label'>
 					<img src={CONFIG.SPRITES['energy_icon'].url} className='ui' />
-					{getChronitonCount()}
+					{getChronitonCount()?.toLocaleString()}
 				</div>
 
 				<div className='ui black large image label'>
 					<img src={CONFIG.SPRITES['images_currency_pp_currency_0'].url} className='ui' />
-					{STTApi.playerData.premium_purchasable}
+					{STTApi.playerData.premium_purchasable?.toLocaleString()}
 				</div>
 
 				<div className='ui black large image label'>
 					<img src={CONFIG.SPRITES['images_currency_pe_currency_0'].url} className='ui' />
-					{STTApi.playerData.premium_earnable}
+					{STTApi.playerData.premium_earnable?.toLocaleString()}
 				</div>
 
 				<div className='ui black large image label'>
 					<img src={CONFIG.SPRITES['images_currency_honor_currency_0'].url} className='ui' />
-					{STTApi.playerData.honor}
+					{STTApi.playerData.honor?.toLocaleString()}
 				</div>
 
 				<div className='ui black large image label'>
 					<img src={CONFIG.SPRITES['images_currency_sc_currency_0'].url} className='ui' />
-					{STTApi.playerData.money}
+					{STTApi.playerData.money?.toLocaleString()}
 				</div>
 
 				{ STTApi.playerData.character.stimpack &&

--- a/src/components/voyage/VoyageCrewSelect.tsx
+++ b/src/components/voyage/VoyageCrewSelect.tsx
@@ -10,686 +10,686 @@ import { calculateVoyage, exportVoyageData, CalcChoice, cleanCrewName, CalcRemai
 import { GetSpriteCssClass } from '../DarkThemeContext';
 
 interface VoyageCrewEntry {
-	key: number;
-	value: number;
-	image: { avatar: boolean; src: string | undefined; };
-	text: string;
+    key: number;
+    value: number;
+    image: { avatar: boolean; src: string | undefined; };
+    text: string;
 }
 
 export const VoyageCrewSelect = (props: {
-	onRefreshNeeded: () => void;
+    onRefreshNeeded: () => void;
 }) => {
-	const [error, setError] = React.useState(undefined as string | undefined);
-	const [generatingVoyCrewRank, setGeneratingVoyCrewRank] = React.useState(false);
-	const [searchDepth, setSearchDepth] = React.useState(6);
-	const [extendsTarget, setExtendsTarget] = React.useState(0);
-	const [includeFrozen, setIncludeFrozen] = React.useState(false);
-	const [includeActive, setIncludeActive] = React.useState(false);
-	const [shipName, setShipName] = React.useState(undefined as string | undefined);
-	const spriteClass = GetSpriteCssClass();
+    const [error, setError] = React.useState(undefined as string | undefined);
+    const [generatingVoyCrewRank, setGeneratingVoyCrewRank] = React.useState(false);
+    const [searchDepth, setSearchDepth] = React.useState(6);
+    const [extendsTarget, setExtendsTarget] = React.useState(0);
+    const [includeFrozen, setIncludeFrozen] = React.useState(false);
+    const [includeActive, setIncludeActive] = React.useState(false);
+    const [shipName, setShipName] = React.useState(undefined as string | undefined);
+    const spriteClass = GetSpriteCssClass();
 
-	const initialCalcState = {
-		estimatedDuration: undefined,
-		state: 'open',
-		crewSelection: []
-	} as {
-		estimatedDuration: number | undefined,
-		state: string,
-		crewSelection: CalcChoice[]
-	}
+    const initialCalcState = {
+        estimatedDuration: undefined,
+        state: 'open',
+        crewSelection: []
+    } as {
+        estimatedDuration: number | undefined,
+        state: string,
+        crewSelection: CalcChoice[]
+    }
 
-	const [calcState, setCalcState] = React.useState(initialCalcState);
+    const [calcState, setCalcState] = React.useState(initialCalcState);
 
-	React.useEffect(() => {
-		if (calcState.state === 'open') {
-			calcVoyageLength();
-		}
-	}, [calcState]);
+    React.useEffect(() => {
+        if (calcState.state === 'open') {
+            calcVoyageLength();
+        }
+    }, [calcState]);
 
-	let bestVoyageShips = bestVoyageShip();
-	const [bestShips, setBestShips] = React.useState(bestVoyageShips);
-	const [selectedShipId, setSelectedShipId] = React.useState(bestVoyageShips[0].ship.id as number | undefined);
+    let bestVoyageShips = bestVoyageShip();
+    const [bestShips, setBestShips] = React.useState(bestVoyageShips);
+    const [selectedShipId, setSelectedShipId] = React.useState(bestVoyageShips[0].ship.id as number | undefined);
 
-	let peopleListVal: VoyageCrewEntry[] = [];
-	STTApi.roster.forEach(crew => {
-		if (includeFrozen || crew.status.frozen <= 0) {
-			peopleListVal.push({
-				key: crew.crew_id || crew.id,
-				value: crew.crew_id || crew.id,
-				image: { avatar: true, src: crew.iconUrl },
-				text: crew.name
-			});
-		}
-	});
-	peopleListVal.sort((a, b) => (a.text < b.text) ? -1 : ((a.text > b.text) ? 1 : 0));
-	//const [peopleList, setPeopleList] = React.useState(peopleListVal);
-	const peopleList = peopleListVal;
+    let peopleListVal: VoyageCrewEntry[] = [];
+    STTApi.roster.forEach(crew => {
+        if (includeFrozen || crew.status.frozen <= 0) {
+            peopleListVal.push({
+                key: crew.crew_id || crew.id,
+                value: crew.crew_id || crew.id,
+                image: { avatar: true, src: crew.iconUrl },
+                text: crew.name
+            });
+        }
+    });
+    peopleListVal.sort((a, b) => (a.text < b.text) ? -1 : ((a.text > b.text) ? 1 : 0));
+    //const [peopleList, setPeopleList] = React.useState(peopleListVal);
+    const peopleList = peopleListVal;
 
-		// See which crew is needed in the event to give the user a chance to remove them from consideration
-	let result = bonusCrewForCurrentEvent(includeFrozen);
-	//const [activeEvent, setActiveEvent] = React.useState(result ? result.eventName : undefined);
-	const activeEvent = result ? result.eventName : undefined;
-	const [currentSelectedItems, setCurrentSelectedItems] = React.useState(result ? result.crewIds : []);
+        // See which crew is needed in the event to give the user a chance to remove them from consideration
+    let result = bonusCrewForCurrentEvent(includeFrozen);
+    //const [activeEvent, setActiveEvent] = React.useState(result ? result.eventName : undefined);
+    const activeEvent = result ? result.eventName : undefined;
+    const [currentSelectedItems, setCurrentSelectedItems] = React.useState(result ? result.crewIds : []);
 
-	React.useEffect(() => {
-		let result = bonusCrewForCurrentEvent(includeFrozen);
-		setCurrentSelectedItems(result ? result.crewIds : []);
-	}, [includeFrozen]);
+    React.useEffect(() => {
+        let result = bonusCrewForCurrentEvent(includeFrozen);
+        setCurrentSelectedItems(result ? result.crewIds : []);
+    }, [includeFrozen]);
 
-	// function getIndexBySlotName(slotName: any) : number | undefined {
-	// 	const crewSlots = STTApi.playerData.character.voyage_descriptions[0].crew_slots;
-	// 	for (let slotIndex = 0; slotIndex < crewSlots.length; slotIndex++) {
-	// 		if (crewSlots[slotIndex].name === slotName) {
-	// 			return slotIndex;
-	// 		}
-	// 	}
-	// }
+    // function getIndexBySlotName(slotName: any) : number | undefined {
+    //     const crewSlots = STTApi.playerData.character.voyage_descriptions[0].crew_slots;
+    //     for (let slotIndex = 0; slotIndex < crewSlots.length; slotIndex++) {
+    //         if (crewSlots[slotIndex].name === slotName) {
+    //             return slotIndex;
+    //         }
+    //     }
+    // }
 
-	let shipSpans = [];
-	for (let entry of bestShips) {
-		shipSpans.push({
-			key: entry.ship.id,
-			text: entry.ship.name,
-			value: entry.ship.id,
-			content: (
-				<Header
-					icon={<img src={entry.ship.iconUrl} height={48} style={{ display: 'inline-block' }} />}
-					content={entry.ship.name}
-					subheader={`${entry.score.toFixed(0)} antimatter`}
-				/>
-			)
-		});
-	}
+    let shipSpans = [];
+    for (let entry of bestShips) {
+        shipSpans.push({
+            key: entry.ship.id,
+            text: entry.ship.name,
+            value: entry.ship.id,
+            content: (
+                <Header
+                    icon={<img src={entry.ship.iconUrl} height={48} style={{ display: 'inline-block' }} />}
+                    content={entry.ship.name}
+                    subheader={`${entry.score.toFixed(0)} antimatter`}
+                />
+            )
+        });
+    }
 
-	let currentPrimarySkillUrl;
-	let currentSecondarySkillUrl;
-	if (STTApi.playerData.character.voyage_descriptions && STTApi.playerData.character.voyage_descriptions.length > 0) {
-		currentPrimarySkillUrl = CONFIG.SPRITES[`icon_${STTApi.playerData.character.voyage_descriptions[0].skills.primary_skill}`].url;
-		currentSecondarySkillUrl = CONFIG.SPRITES[`icon_${STTApi.playerData.character.voyage_descriptions[0].skills.secondary_skill}`].url;
-	}
-	let voyage: VoyageDTO | undefined = undefined;
-	if (STTApi.playerData.character.voyage && STTApi.playerData.character.voyage.length > 0) {
-		voyage = STTApi.playerData.character.voyage[0];
-		currentPrimarySkillUrl = CONFIG.SPRITES[`icon_${voyage.skills.primary_skill}`].url;
-		currentSecondarySkillUrl = CONFIG.SPRITES[`icon_${voyage.skills.secondary_skill}`].url;
-	}
+    let currentPrimarySkillUrl;
+    let currentSecondarySkillUrl;
+    if (STTApi.playerData.character.voyage_descriptions && STTApi.playerData.character.voyage_descriptions.length > 0) {
+        currentPrimarySkillUrl = CONFIG.SPRITES[`icon_${STTApi.playerData.character.voyage_descriptions[0].skills.primary_skill}`].url;
+        currentSecondarySkillUrl = CONFIG.SPRITES[`icon_${STTApi.playerData.character.voyage_descriptions[0].skills.secondary_skill}`].url;
+    }
+    let voyage: VoyageDTO | undefined = undefined;
+    if (STTApi.playerData.character.voyage && STTApi.playerData.character.voyage.length > 0) {
+        voyage = STTApi.playerData.character.voyage[0];
+        currentPrimarySkillUrl = CONFIG.SPRITES[`icon_${voyage.skills.primary_skill}`].url;
+        currentSecondarySkillUrl = CONFIG.SPRITES[`icon_${voyage.skills.secondary_skill}`].url;
+    }
 
-	const estDurationSec = (calcState.estimatedDuration ?? 0) * 60 * 60;
-	const estRecallDurationSec = 0.4 * (estDurationSec);
-	return (
-		<div>
-			<h1>Start Voyage</h1>
-			<Message attached>
-				<div className='voyage-skillsets'>
-					<div>Primary:</div>
-					<div><img className={`image-fit ${spriteClass}`} src={currentPrimarySkillUrl} /></div>
-					<div>Secondary:</div>
-					<div><img className={`image-fit ${spriteClass}`} src={currentSecondarySkillUrl} /></div>
-				</div>
-				<div>Configure the settings below, then click on the "Calculate" button to see the recommendations.</div>
-			</Message>
-			<Form className='attached fluid segment' loading={generatingVoyCrewRank || calcState.state === 'inprogress'}>
-				<Form.Group inline>
-					<Form.Field
-						control={Select}
-						label='Search depth'
-						options={[
-							{ key: '4', text: '4 (fastest)', value: 4 },
-							{ key: '5', text: '5 (faster)', value: 5 },
-							{ key: '6', text: '6 (normal)', value: 6 },
-							{ key: '7', text: '7 (slower)', value: 7 },
-							{ key: '8', text: '8 (slowest)', value: 8 },
-							{ key: '9', text: '9 (for supercomputers)', value: 9 }
-						]}
-						value={searchDepth}
-						onChange={(e: any, { value }: any) => setSearchDepth(value)}
-						placeholder='Search depth'
-					/>
-					<Form.Field
-						control={Select}
-						label='Extends (target)'
-						options={[
-							{ key: '0', text: 'none (default)', value: 0 },
-							{ key: '1', text: 'one', value: 1 },
-							{ key: '2', text: 'two', value: 2 }
-						]}
-						value={extendsTarget}
-						onChange={(e:any, { value }:any) => setExtendsTarget(value)}
-						placeholder='How many times you plan to revive'
-					/>
-				</Form.Group>
+    const estDurationSec = (calcState.estimatedDuration ?? 0) * 60 * 60;
+    const estRecallDurationSec = 0.4 * (estDurationSec);
+    return (
+        <div>
+            <h1>Start Voyage</h1>
+            <Message attached>
+                <div className='voyage-skillsets'>
+                    <div>Primary:</div>
+                    <div><img className={`image-fit ${spriteClass}`} src={currentPrimarySkillUrl} /></div>
+                    <div>Secondary:</div>
+                    <div><img className={`image-fit ${spriteClass}`} src={currentSecondarySkillUrl} /></div>
+                </div>
+                <div>Configure the settings below, then click on the "Calculate" button to see the recommendations.</div>
+            </Message>
+            <Form className='attached fluid segment' loading={generatingVoyCrewRank || calcState.state === 'inprogress'}>
+                <Form.Group inline>
+                    <Form.Field
+                        control={Select}
+                        label='Search depth'
+                        options={[
+                            { key: '4', text: '4 (fastest)', value: 4 },
+                            { key: '5', text: '5 (faster)', value: 5 },
+                            { key: '6', text: '6 (normal)', value: 6 },
+                            { key: '7', text: '7 (slower)', value: 7 },
+                            { key: '8', text: '8 (slowest)', value: 8 },
+                            { key: '9', text: '9 (for supercomputers)', value: 9 }
+                        ]}
+                        value={searchDepth}
+                        onChange={(e: any, { value }: any) => setSearchDepth(value)}
+                        placeholder='Search depth'
+                    />
+                    <Form.Field
+                        control={Select}
+                        label='Extends (target)'
+                        options={[
+                            { key: '0', text: 'none (default)', value: 0 },
+                            { key: '1', text: 'one', value: 1 },
+                            { key: '2', text: 'two', value: 2 }
+                        ]}
+                        value={extendsTarget}
+                        onChange={(e:any, { value }:any) => setExtendsTarget(value)}
+                        placeholder='How many times you plan to revive'
+                    />
+                </Form.Group>
 
-				<Form.Group inline>
-					<Form.Field>
-						<label>Choose a ship (Bonus: {STTApi.playerData.character.voyage_descriptions[0].ship_trait})</label>
-						<Dropdown
-							className='ship-dropdown'
-							selection
-							options={shipSpans}
-							placeholder='Choose a ship for your voyage'
-							value={selectedShipId}
-							onChange={(ev, { value }) => setSelectedShipId(value !== undefined ? +value : undefined)}
-						/>
-					</Form.Field>
+                <Form.Group inline>
+                    <Form.Field>
+                        <label>Choose a ship (Bonus: {STTApi.playerData.character.voyage_descriptions[0].ship_trait})</label>
+                        <Dropdown
+                            className='ship-dropdown'
+                            selection
+                            options={shipSpans}
+                            placeholder='Choose a ship for your voyage'
+                            value={selectedShipId}
+                            onChange={(ev, { value }) => setSelectedShipId(value !== undefined ? +value : undefined)}
+                        />
+                    </Form.Field>
 
-					<Form.Input
-						label='Ship name'
-						value={shipName}
-						placeholder={bestShips.find((s) => s.ship.id == selectedShipId)!.ship.name}
-						onChange={(ev, { value }) => setShipName(value)}
-					/>
-				</Form.Group>
+                    <Form.Input
+                        label='Ship name'
+                        value={shipName}
+                        placeholder={bestShips.find((s) => s.ship.id == selectedShipId)!.ship.name}
+                        onChange={(ev, { value }) => setShipName(value)}
+                    />
+                </Form.Group>
 
-				<Form.Group>
-					<Form.Field
-						control={Dropdown}
-						clearable
-						fluid
-						multiple
-						search
-						selection
-						options={peopleList}
-						placeholder='Select or search for crew'
-						label={
-							"Crew you don't want to consider for voyage" +
-							(activeEvent ? ` (preselected crew which gives bonus in the event ${activeEvent})` : '')
-						}
-						value={currentSelectedItems}
-						onChange={(e: any, { value }: any) => setCurrentSelectedItems(value)}
-					/>
-				</Form.Group>
+                <Form.Group>
+                    <Form.Field
+                        control={Dropdown}
+                        clearable
+                        fluid
+                        multiple
+                        search
+                        selection
+                        options={peopleList}
+                        placeholder='Select or search for crew'
+                        label={
+                            "Crew you don't want to consider for voyage" +
+                            (activeEvent ? ` (preselected crew which gives bonus in the event ${activeEvent})` : '')
+                        }
+                        value={currentSelectedItems}
+                        onChange={(e: any, { value }: any) => setCurrentSelectedItems(value)}
+                    />
+                </Form.Group>
 
-				<Form.Group inline>
-					<Form.Field
-						control={Checkbox}
-						label='Include active (on shuttles) crew'
-						checked={includeActive}
-						onChange={(e: any, { checked }: any) => setIncludeActive(checked)}
-					/>
+                <Form.Group inline>
+                    <Form.Field
+                        control={Checkbox}
+                        label='Include active (on shuttles) crew'
+                        checked={includeActive}
+                        onChange={(e: any, { checked }: any) => setIncludeActive(checked)}
+                    />
 
-					<Form.Field
-						control={Checkbox}
-						label='Include frozen (vaulted) crew'
-						checked={includeFrozen}
-						onChange={(e: any, { checked }: any) => setIncludeFrozen(checked)}
-					/>
-				</Form.Group>
+                    <Form.Field
+                        control={Checkbox}
+                        label='Include frozen (vaulted) crew'
+                        checked={includeFrozen}
+                        onChange={(e: any, { checked }: any) => setIncludeFrozen(checked)}
+                    />
+                </Form.Group>
 
-				{(calcState.state === 'inprogress' || calcState.state === 'done') && (<>
-					<h3>
-						Estimated duration: <b>{formatTimeSeconds(estDurationSec)}</b>
-					</h3>
-					<h5>
-					Including recall: {formatTimeSeconds(estDurationSec + estRecallDurationSec)} at {
-					Moment().add(estDurationSec + estRecallDurationSec, 's').format('h:mma')}
-					</h5>
-					</>
-				)}
+                {(calcState.state === 'inprogress' || calcState.state === 'done') && (<>
+                    <h3>
+                        Estimated duration: <b>{formatTimeSeconds(estDurationSec)}</b>
+                    </h3>
+                    <h5>
+                    Including recall: {formatTimeSeconds(estDurationSec + estRecallDurationSec)} at {
+                    Moment().add(estDurationSec + estRecallDurationSec, 's').format('h:mma')}
+                    </h5>
+                    </>
+                )}
 
-				<Form.Group>
-					<Form.Button primary onClick={_calcVoyageData} disabled={calcState.state === 'inprogress'}>
-						Calculate best crew selection
-					</Form.Button>
-					<Form.Button secondary onClick={_startVoyage} disabled={calcState.state !== 'done' || voyage !== undefined}>
-						Start voyage with recommendations
-					</Form.Button>
+                <Form.Group>
+                    <Form.Button primary onClick={_calcVoyageData} disabled={calcState.state === 'inprogress'}>
+                        Calculate best crew selection
+                    </Form.Button>
+                    <Form.Button secondary onClick={_startVoyage} disabled={calcState.state !== 'done' || voyage !== undefined}>
+                        Start voyage with recommendations
+                    </Form.Button>
 
-					{/* #!if ENV === 'electron' */}
-					<Form.Button onClick={() => _generateVoyCrewRank()} disabled={calcState.state === 'inprogress'}>
-						Export CSV with crew Voyage ranking...
-					</Form.Button>
-					{/* #!endif */}
-				</Form.Group>
-			</Form>
-			<Message attached='bottom' error hidden={!error}>
-				Error: {error}
-			</Message>
+                    {/* #!if ENV === 'electron' */}
+                    <Form.Button onClick={() => _generateVoyCrewRank()} disabled={calcState.state === 'inprogress'}>
+                        Export CSV with crew Voyage ranking...
+                    </Form.Button>
+                    {/* #!endif */}
+                </Form.Group>
+            </Form>
+            <Message attached='bottom' error hidden={!error}>
+                Error: {error}
+            </Message>
 
-			<BestCrew
-				state={calcState.state}
-				crewSelection={calcState.crewSelection}
-				crewAvailable={getAvailableCrew()}
-				crewUpdated={crewSelectionChanged} />
-		</div>
-	);
+            <BestCrew
+                state={calcState.state}
+                crewSelection={calcState.crewSelection}
+                crewAvailable={getAvailableCrew()}
+                crewUpdated={crewSelectionChanged} />
+        </div>
+    );
 
-	function crewSelectionChanged(selection: CalcChoice[]) {
-		setCalcState({
-			crewSelection: selection,
-			estimatedDuration: 0,
-			state: 'open'
-		});
-	}
+    function crewSelectionChanged(selection: CalcChoice[]) {
+        setCalcState({
+            crewSelection: selection,
+            estimatedDuration: 0,
+            state: 'open'
+        });
+    }
 
-	function _startVoyage() {
-		let selectedCrewIds = [];
-		for (let i = 0; i < STTApi.playerData.character.voyage_descriptions[0].crew_slots.length; i++) {
-			let entry = calcState.crewSelection.find((entry) => entry.slotId === i);
-			if (!entry) {
-				setError(`Cannot start voyage with unknown crew slot '${i}'`);
-				return;
-			}
+    function _startVoyage() {
+        let selectedCrewIds = [];
+        for (let i = 0; i < STTApi.playerData.character.voyage_descriptions[0].crew_slots.length; i++) {
+            let entry = calcState.crewSelection.find((entry) => entry.slotId === i);
+            if (!entry) {
+                setError(`Cannot start voyage with unknown crew slot '${i}'`);
+                return;
+            }
 
-			if (!entry.choice.crew_id || entry.choice.active_id) {
-				setError(`Cannot start voyage with frozen or active crew '${entry.choice.name}'`);
-				return;
-			}
+            if (!entry.choice.crew_id || entry.choice.active_id) {
+                setError(`Cannot start voyage with frozen or active crew '${entry.choice.name}'`);
+                return;
+            }
 
-			selectedCrewIds.push(entry.choice.crew_id);
-		}
+            selectedCrewIds.push(entry.choice.crew_id);
+        }
 
-		if (!selectedShipId) {
-			setError(`Cannot start voyage without a selected ship`);
-			return;
-		}
+        if (!selectedShipId) {
+            setError(`Cannot start voyage without a selected ship`);
+            return;
+        }
 
-		startVoyage(
-			STTApi.playerData.character.voyage_descriptions[0].symbol,
-			selectedShipId,
-			shipName,
-			selectedCrewIds
-		)
-			.then(() => {
-				props.onRefreshNeeded();
-			})
-			.catch(err => {
-				setError(err.message);
-			});
-	}
+        startVoyage(
+            STTApi.playerData.character.voyage_descriptions[0].symbol,
+            selectedShipId,
+            shipName,
+            selectedCrewIds
+        )
+            .then(() => {
+                props.onRefreshNeeded();
+            })
+            .catch(err => {
+                setError(err.message);
+            });
+    }
 
-	function getAvailableCrew() {
-		return STTApi.roster.filter(crew => {
-			// Filter out buy-back crew
-			if (crew.buyback) {
-				return false;
-			}
+    function getAvailableCrew() {
+        return STTApi.roster.filter(crew => {
+            // Filter out buy-back crew
+            if (crew.buyback) {
+                return false;
+            }
 
-			if (!includeActive && crew.active_id) {
-				return false;
-			}
+            if (!includeActive && crew.active_id) {
+                return false;
+            }
 
-			if (!includeFrozen && crew.frozen > 0) {
-				return false;
-			}
+            if (!includeFrozen && crew.frozen > 0) {
+                return false;
+            }
 
-			// Filter out crew the user has chosen not to include
-			if (
-				currentSelectedItems.length > 0 &&
-				currentSelectedItems.some((ignored) => ignored === (crew.crew_id || crew.id))
-			) {
-				return false;
-			}
+            // Filter out crew the user has chosen not to include
+            if (
+                currentSelectedItems.length > 0 &&
+                currentSelectedItems.some((ignored) => ignored === (crew.crew_id || crew.id))
+            ) {
+                return false;
+            }
 
-			return true;
-		});
-	}
+            return true;
+        });
+    }
 
-	function _packVoyageOptions() : CalcOptions {
-		let filteredRoster = getAvailableCrew();
+    function _packVoyageOptions() : CalcOptions {
+        let filteredRoster = getAvailableCrew();
 
-		return {
-			searchDepth: searchDepth,
-			extendsTarget: extendsTarget,
-			shipAM: bestShips.find((s) => s.ship.id == selectedShipId)!.score,
-			skillPrimaryMultiplier: 3.5,
-			skillSecondaryMultiplier: 2.5,
-			skillMatchingMultiplier: 1.1,
-			traitScoreBoost: 200,
-			voyage_description: STTApi.playerData.character.voyage_descriptions[0],
-			roster: filteredRoster
-		};
-	}
+        return {
+            searchDepth: searchDepth,
+            extendsTarget: extendsTarget,
+            shipAM: bestShips.find((s) => s.ship.id == selectedShipId)!.score,
+            skillPrimaryMultiplier: 3.5,
+            skillSecondaryMultiplier: 2.5,
+            skillMatchingMultiplier: 1.1,
+            traitScoreBoost: 200,
+            voyage_description: STTApi.playerData.character.voyage_descriptions[0],
+            roster: filteredRoster
+        };
+    }
 
-	function _calcVoyageData() {
-		let options = _packVoyageOptions();
+    function _calcVoyageData() {
+        let options = _packVoyageOptions();
 
-		calculateVoyage(
-			options,
-			(entries: CalcChoice[], score: number) => {
-				setCalcState({
-					crewSelection: entries,
-					estimatedDuration: score,
-					state: 'inprogress'
-				});
-			},
-			(entries: CalcChoice[], score: number) => {
-				setCalcState({
-					crewSelection: entries,
-					estimatedDuration: score,
-					state: 'done'
-				});
-			}
-		);
-	}
+        calculateVoyage(
+            options,
+            (entries: CalcChoice[], score: number) => {
+                setCalcState({
+                    crewSelection: entries,
+                    estimatedDuration: score,
+                    state: 'inprogress'
+                });
+            },
+            (entries: CalcChoice[], score: number) => {
+                setCalcState({
+                    crewSelection: entries,
+                    estimatedDuration: score,
+                    state: 'done'
+                });
+            }
+        );
+    }
 
-	function calcVoyageLength() {
-		const numSlots = STTApi.playerData.character.voyage_descriptions[0].crew_slots.length;
-		if (calcState.crewSelection.length < numSlots) {
-			return;
-		}
-		const assignedRoster: CrewData[] = calcState.crewSelection.map(cs => cs.choice);
-		const assignedCrewIds: number[] = calcState.crewSelection.map(cs => cs.choice.id);
+    function calcVoyageLength() {
+        const numSlots = STTApi.playerData.character.voyage_descriptions[0].crew_slots.length;
+        if (calcState.crewSelection.length < numSlots) {
+            return;
+        }
+        const assignedRoster: CrewData[] = calcState.crewSelection.map(cs => cs.choice);
+        const assignedCrewIds: number[] = calcState.crewSelection.map(cs => cs.choice.id);
 
-		//TODO: need to do any validation here to prevent the native code from crashing
-		if (assignedRoster.length == 0) {
-			console.log('Unable to estimate; roster is empty');
-			return;
-		}
+        //TODO: need to do any validation here to prevent the native code from crashing
+        if (assignedRoster.length == 0) {
+            console.log('Unable to estimate; roster is empty');
+            return;
+        }
 
-		let options: CalcRemainingOptions = {
-			// first three not needed for estimate calculation
-			searchDepth: 0,
-			extendsTarget: 0,
-			shipAM: 0,
-			skillPrimaryMultiplier: 3.5,
-			skillSecondaryMultiplier: 2.5,
-			skillMatchingMultiplier: 1.1,
-			traitScoreBoost: 200,
-			voyage_description: STTApi.playerData.character.voyage_descriptions[0],
-			roster: assignedRoster,
-			// Estimate-specific parameters
-			voyage_duration: 0,
-			remainingAntiMatter: bestShips.find((s) => s.ship.id == selectedShipId)!.score,
-			assignedCrew: assignedCrewIds
-		};
+        let options: CalcRemainingOptions = {
+            // first three not needed for estimate calculation
+            searchDepth: 0,
+            extendsTarget: 0,
+            shipAM: 0,
+            skillPrimaryMultiplier: 3.5,
+            skillSecondaryMultiplier: 2.5,
+            skillMatchingMultiplier: 1.1,
+            traitScoreBoost: 200,
+            voyage_description: STTApi.playerData.character.voyage_descriptions[0],
+            roster: assignedRoster,
+            // Estimate-specific parameters
+            voyage_duration: 0,
+            remainingAntiMatter: bestShips.find((s) => s.ship.id == selectedShipId)!.score,
+            assignedCrew: assignedCrewIds
+        };
 
-		setCalcState({
-			crewSelection: calcState.crewSelection,
-			estimatedDuration: calcState.estimatedDuration,
-			state: 'inprogress'
-		});
+        setCalcState({
+            crewSelection: calcState.crewSelection,
+            estimatedDuration: calcState.estimatedDuration,
+            state: 'inprogress'
+        });
 
-		estimateVoyageRemaining(options, (minutesLeft) => {
-			setCalcState({
-				crewSelection: calcState.crewSelection,
-				estimatedDuration: minutesLeft / 60,
-				state: 'done'
-			});
-		});
-	}
+        estimateVoyageRemaining(options, (minutesLeft) => {
+            setCalcState({
+                crewSelection: calcState.crewSelection,
+                estimatedDuration: minutesLeft / 60,
+                state: 'done'
+            });
+        });
+    }
 
-	// #!if ENV === 'electron'
-	function _generateVoyCrewRank() {
-		function nthIndex(str:string, pat:string, n:number) {
-			let L = str.length, i = -1;
-			while (n-- && i++ < L) {
-				i = str.indexOf(pat, i);
-				if (i < 0) break;
-			}
-			return i;
-		}
+    // #!if ENV === 'electron'
+    function _generateVoyCrewRank() {
+        function nthIndex(str:string, pat:string, n:number) {
+            let L = str.length, i = -1;
+            while (n-- && i++ < L) {
+                i = str.indexOf(pat, i);
+                if (i < 0) break;
+            }
+            return i;
+        }
 
-		setGeneratingVoyCrewRank(true);
+        setGeneratingVoyCrewRank(true);
 
-		let voyOpts = _packVoyageOptions();
-		// Clear trait score boost when generating voyage crew rankings. This improves stability
-		// on crew usage across voyage skill pairs over
-		voyOpts.traitScoreBoost = 0;
+        let voyOpts = _packVoyageOptions();
+        // Clear trait score boost when generating voyage crew rankings. This improves stability
+        // on crew usage across voyage skill pairs over
+        voyOpts.traitScoreBoost = 0;
 
-		let dataToExport = exportVoyageData(voyOpts);
+        let dataToExport = exportVoyageData(voyOpts);
 
-		const NativeExtension = require('electron').remote.require('stt-native');
-		NativeExtension.calculateVoyageCrewRank(
-			JSON.stringify(dataToExport),
-			(rankResult: string, estimateResult: string) => {
-				// estimateResult is of the form "Primary,Secondary,Estimate,Crew\nDIP, CMD, 8.2, crew1 | crew2 | crew3 | crew4 | crew5 | ... crew12\nCMD, DIP, 8.2, crew1 | ... "
-				// crew names may have spaces and commas
-				let lines = estimateResult.split('\n');
-				let estimateResultSplit = "";
-				lines.forEach((line: string,index:number) => {
-					// skip column headers line
-					if (index <= 0) {
-						estimateResultSplit += line + '\n';
-						return;
-					}
-					if (line.trim().length <= 0) {
-						return;
-					}
-					let posEst = nthIndex(line, ',', 2);
-					let posNames = nthIndex(line, ',', 3);
-					let est = line.substring(posEst+1, posNames);
-					if (est.indexOf('.') >= 0) {
-						let whole = est.substring(0, est.indexOf('.'));
-						let part : string | number = est.substring(whole.length); // include decimal
-						if (part.length > 0) {
-							part = 60 * Number(part);
-							if (part < 10)
-								part = '0' + part;
-						}
-						else {
-							part = '00';
-						}
-						est = whole + ':' + part;
-					}
-					else {
-						est = est + ':00';
-					}
-					let crewline = line.substring(posNames+1);
-					let crewlist = crewline.split('|');
+        const NativeExtension = require('electron').remote.require('stt-native');
+        NativeExtension.calculateVoyageCrewRank(
+            JSON.stringify(dataToExport),
+            (rankResult: string, estimateResult: string) => {
+                // estimateResult is of the form "Primary,Secondary,Estimate,Crew\nDIP, CMD, 8.2, crew1 | crew2 | crew3 | crew4 | crew5 | ... crew12\nCMD, DIP, 8.2, crew1 | ... "
+                // crew names may have spaces and commas
+                let lines = estimateResult.split('\n');
+                let estimateResultSplit = "";
+                lines.forEach((line: string,index:number) => {
+                    // skip column headers line
+                    if (index <= 0) {
+                        estimateResultSplit += line + '\n';
+                        return;
+                    }
+                    if (line.trim().length <= 0) {
+                        return;
+                    }
+                    let posEst = nthIndex(line, ',', 2);
+                    let posNames = nthIndex(line, ',', 3);
+                    let est = line.substring(posEst+1, posNames);
+                    if (est.indexOf('.') >= 0) {
+                        let whole = est.substring(0, est.indexOf('.'));
+                        let part : string | number = est.substring(whole.length); // include decimal
+                        if (part.length > 0) {
+                            part = 60 * Number(part);
+                            if (part < 10)
+                                part = '0' + part;
+                        }
+                        else {
+                            part = '00';
+                        }
+                        est = whole + ':' + part;
+                    }
+                    else {
+                        est = est + ':00';
+                    }
+                    let crewline = line.substring(posNames+1);
+                    let crewlist = crewline.split('|');
 
-					crewlist = crewlist.map(s => s.trim());// don't sort so you can see position assignments //.sort();
+                    crewlist = crewlist.map(s => s.trim());// don't sort so you can see position assignments //.sort();
 
-					estimateResultSplit += line.substring(0, posEst) + ',' + est + ', "' + crewlist.join(' | ') + '"\n'; // join back with pipe to make easier equations
-				});
+                    estimateResultSplit += line.substring(0, posEst) + ',' + est + ', "' + crewlist.join(' | ') + '"\n'; // join back with pipe to make easier equations
+                });
 
-				setGeneratingVoyCrewRank(false);
+                setGeneratingVoyCrewRank(false);
 
-				// Now also update rankResult to add crew usage value column
-				// Format is: "Score,Alt 1,Alt 2,Alt 3,Alt 4,Alt 5,Status,Crew,Voyages (Pri),Voyages(alt)"
-				let linesCrew = rankResult.split('\n');
-				let rankResultSplit = "";
-				let includedCrew : { [cid:number]: CrewData } = {};
-				linesCrew.forEach((line:string, index:number) => {
-					let posName = nthIndex(line, ',', 7);
-					let partA = line.substring(0, posName);
-					let partB = line.substring(posName);
-					// If first line of titles
-					if (index <= 0) {
-						rankResultSplit += partA + ",Value" + partB + '\n';
-						return;
-					}
+                // Now also update rankResult to add crew usage value column
+                // Format is: "Score,Alt 1,Alt 2,Alt 3,Alt 4,Alt 5,Status,Crew,Voyages (Pri),Voyages(alt)"
+                let linesCrew = rankResult.split('\n');
+                let rankResultSplit = "";
+                let includedCrew : { [cid:number]: CrewData } = {};
+                linesCrew.forEach((line:string, index:number) => {
+                    let posName = nthIndex(line, ',', 7);
+                    let partA = line.substring(0, posName);
+                    let partB = line.substring(posName);
+                    // If first line of titles
+                    if (index <= 0) {
+                        rankResultSplit += partA + ",Value" + partB + '\n';
+                        return;
+                    }
 
-					let posStatus = nthIndex(line, ',', 6);
-					partA = line.substring(0, posStatus);
-					//let partB = line.substring(posName);
+                    let posStatus = nthIndex(line, ',', 6);
+                    partA = line.substring(0, posStatus);
+                    //let partB = line.substring(posName);
 
 
-					let value : string | number = "";
-					let status : string | number = line.substring(posStatus +1, posName);
-					// Crew name should be in double quotes after a comma within partB
-					let posNameEnd = partB.indexOf('"',2);
-					if (posNameEnd > 0) {
-						let crewName = partB.substring(2, posNameEnd);
-						let crew = STTApi.roster.find(crew => cleanCrewName(crew.name) == crewName);
-						if (crew && crew.usage_value !== undefined) {
-							value = crew.usage_value;
-						}
-						if (crew) {
-							includedCrew[crew.id] = crew;
-							status = crew.rarity == crew.max_rarity ? crew.max_rarity : (crew.rarity + '/' + crew.max_rarity);
-							if (crew.frozen > 0)
-								status += 'Frz';
-							else if (crew.level == 100 && crew.rarity == crew.max_rarity)
-								status += 'Imm';
-						}
-					}
+                    let value : string | number = "";
+                    let status : string | number = line.substring(posStatus +1, posName);
+                    // Crew name should be in double quotes after a comma within partB
+                    let posNameEnd = partB.indexOf('"',2);
+                    if (posNameEnd > 0) {
+                        let crewName = partB.substring(2, posNameEnd);
+                        let crew = STTApi.roster.find(crew => cleanCrewName(crew.name) == crewName);
+                        if (crew && crew.usage_value !== undefined) {
+                            value = crew.usage_value;
+                        }
+                        if (crew) {
+                            includedCrew[crew.id] = crew;
+                            status = crew.rarity == crew.max_rarity ? crew.max_rarity : (crew.rarity + '/' + crew.max_rarity);
+                            if (crew.frozen > 0)
+                                status += 'Frz';
+                            else if (crew.level == 100 && crew.rarity == crew.max_rarity)
+                                status += 'Imm';
+                        }
+                    }
 
-					rankResultSplit += partA + ',' + status + ',' + value + partB + '\n'; // join back with pipe to make easier equations
-				});
+                    rankResultSplit += partA + ',' + status + ',' + value + partB + '\n'; // join back with pipe to make easier equations
+                });
 
-				// Inject any crew with a usage value but no voyage score
-				STTApi.roster.forEach(crew => {
-					if (!includedCrew[crew.id]) {
-						if (crew.buyback || crew.isExternal || crew.usage_value === undefined)
-							return;
-						if (crew.usage_value > 0 || (crew.max_rarity > 3 && crew.frozen < 1)) {
-							includedCrew[crew.id] = crew;
-							let status : string | number = crew.rarity == crew.max_rarity ? crew.max_rarity : (crew.rarity + '/' + crew.max_rarity);
-							if (crew.frozen > 0)
-								status += 'Frz';
-							else if (crew.level == 100 && crew.rarity == crew.max_rarity)
-								status += 'Imm';
-							else if (crew.level < 100)
-								status += ':' + crew.level;
+                // Inject any crew with a usage value but no voyage score
+                STTApi.roster.forEach(crew => {
+                    if (!includedCrew[crew.id]) {
+                        if (crew.buyback || crew.isExternal || crew.usage_value === undefined)
+                            return;
+                        if (crew.usage_value > 0 || (crew.max_rarity > 3 && crew.frozen < 1)) {
+                            includedCrew[crew.id] = crew;
+                            let status : string | number = crew.rarity == crew.max_rarity ? crew.max_rarity : (crew.rarity + '/' + crew.max_rarity);
+                            if (crew.frozen > 0)
+                                status += 'Frz';
+                            else if (crew.level == 100 && crew.rarity == crew.max_rarity)
+                                status += 'Imm';
+                            else if (crew.level < 100)
+                                status += ':' + crew.level;
 
-							rankResultSplit += '0,,,,,,' + status + ',' + crew.usage_value + ',"' +cleanCrewName(crew.name)+'",,\n';
-						}
-					}
-				});
+                            rankResultSplit += '0,,,,,,' + status + ',' + crew.usage_value + ',"' +cleanCrewName(crew.name)+'",,\n';
+                        }
+                    }
+                });
 
-				download('My Voyage Crew.csv', rankResultSplit, 'Export Star Trek Timelines voyage crew ranking', 'Export');
-				download('My Voyage Estimates.csv', estimateResultSplit, 'Export Star Trek Timelines voyage estimates', 'Export');
-			},
-			(progressResult:any) => {
-				console.log('unexpected progress result!'); // not implemented yet..
-			}
-		);
-	}
-	// #!endif
+                download('My Voyage Crew.csv', rankResultSplit, 'Export Star Trek Timelines voyage crew ranking', 'Export');
+                download('My Voyage Estimates.csv', estimateResultSplit, 'Export Star Trek Timelines voyage estimates', 'Export');
+            },
+            (progressResult:any) => {
+                console.log('unexpected progress result!'); // not implemented yet..
+            }
+        );
+    }
+    // #!endif
 }
 
 const BestCrew = (props : {
-	state: string,
-	crewSelection: CalcChoice[],
-	crewAvailable: CrewData[],
-	crewUpdated: (selection: CalcChoice[]) => void
+    state: string,
+    crewSelection: CalcChoice[],
+    crewAvailable: CrewData[],
+    crewUpdated: (selection: CalcChoice[]) => void
 }) => {
-	const [selectSlotId, setSelectSlotId] = React.useState(undefined as number | undefined);
+    const [selectSlotId, setSelectSlotId] = React.useState(undefined as number | undefined);
 
-	let skill_aggregates: { [sk: string]: { skill: string; core: number; range_min: number; range_max: number; } } = {};
-	Object.keys(CONFIG.SKILLS).forEach(sk => skill_aggregates[sk] = { skill : sk, core : 0, range_max: 0, range_min: 0});
+    let skill_aggregates: { [sk: string]: { skill: string; core: number; range_min: number; range_max: number; } } = {};
+    Object.keys(CONFIG.SKILLS).forEach(sk => skill_aggregates[sk] = { skill : sk, core : 0, range_max: 0, range_min: 0});
 
-	if (props.state === 'inprogress' || props.state === 'done' || props.state === 'open') {
-		let crewSpans: any[] = [];
-		props.crewSelection.forEach((entry) => {
-			if (entry.choice) {
-				let isShuttle = false;
-				STTApi.playerData.character.shuttle_adventures.forEach((shuttle) => {
-					if (shuttle.shuttles[0].id === entry.choice.active_id) {
-						isShuttle = true;
-					}
-				});
+    if (props.state === 'inprogress' || props.state === 'done' || props.state === 'open') {
+        let crewSpans: any[] = [];
+        props.crewSelection.forEach((entry) => {
+            if (entry.choice) {
+                let isShuttle = false;
+                STTApi.playerData.character.shuttle_adventures.forEach((shuttle) => {
+                    if (shuttle.shuttles[0].id === entry.choice.active_id) {
+                        isShuttle = true;
+                    }
+                });
 
-				let trait = STTApi.playerData.character.voyage_descriptions[0].crew_slots[entry.slotId].trait;
-				let traitDisp = STTApi.getTraitName(trait);
-				let traitMatch = entry.choice.rawTraits.find(t => t === trait);
+                let trait = STTApi.playerData.character.voyage_descriptions[0].crew_slots[entry.slotId].trait;
+                let traitDisp = STTApi.getTraitName(trait);
+                let traitMatch = entry.choice.rawTraits.find(t => t === trait);
 
-				let status = entry.choice.frozen > 0 ? 'Frozen' : entry.choice.active_id ? isShuttle ? 'On Shuttle' : 'On Voyage' : 'Available';
-				let crewCard =
-					<Card key={entry.choice.crew_id || entry.choice.id} color={status === 'Frozen' ? 'red' : status === 'Available' ? 'green' : 'yellow'}>
-						<Card.Content>
-							<Image floated='right' size='mini' src={entry.choice.iconUrl} />
-							<Card.Header>{entry.choice.name}</Card.Header>
-							<Card.Meta>
-								{STTApi.playerData.character.voyage_descriptions[0].crew_slots[entry.slotId].name}<br/>
-								{traitMatch ? <b>{traitDisp} (Match)</b> : traitDisp }
-							</Card.Meta>
-							<Card.Description>
-								<CrewSkills crew={entry.choice} useIcon={false} asVoyScore={true} addVoyTotal={true} starBreakSpace={true} voyBreakSpace={true} />
-							</Card.Description>
-						</Card.Content>
-						<Card.Content extra>
-							Status: {status} <Button onClick={() => setSelectSlotId(selectSlotId !== undefined ? undefined : entry.slotId)} style={{float:'right'}} content='Select'/>
-						</Card.Content>
-					</Card>;
+                let status = entry.choice.frozen > 0 ? 'Frozen' : entry.choice.active_id ? isShuttle ? 'On Shuttle' : 'On Voyage' : 'Available';
+                let crewCard =
+                    <Card key={entry.choice.crew_id || entry.choice.id} color={status === 'Frozen' ? 'red' : status === 'Available' ? 'green' : 'yellow'}>
+                        <Card.Content>
+                            <Image floated='right' size='mini' src={entry.choice.iconUrl} />
+                            <Card.Header>{entry.choice.name}</Card.Header>
+                            <Card.Meta>
+                                {STTApi.playerData.character.voyage_descriptions[0].crew_slots[entry.slotId].name}<br/>
+                                {traitMatch ? <b>{traitDisp} (Match)</b> : traitDisp }
+                            </Card.Meta>
+                            <Card.Description>
+                                <CrewSkills crew={entry.choice} useIcon={false} asVoyScore={true} addVoyTotal={true} starBreakSpace={true} voyBreakSpace={true} />
+                            </Card.Description>
+                        </Card.Content>
+                        <Card.Content extra>
+                            Status: {status} <Button onClick={() => setSelectSlotId(selectSlotId !== undefined ? undefined : entry.slotId)} style={{float:'right'}} content='Select'/>
+                        </Card.Content>
+                    </Card>;
 
-				crewSpans[entry.slotId] = crewCard;
+                crewSpans[entry.slotId] = crewCard;
 
-				Object.keys(entry.choice.skills).forEach(sk => {
-					let sd = entry.choice.skills[sk];
-					skill_aggregates[sk].core += sd.core;
-					skill_aggregates[sk].range_min += sd.min;
-					skill_aggregates[sk].range_max += sd.max;
-				});
-			} else {
-				console.error(entry);
-			}
-		});
+                Object.keys(entry.choice.skills).forEach(sk => {
+                    let sd = entry.choice.skills[sk];
+                    skill_aggregates[sk].core += sd.core;
+                    skill_aggregates[sk].range_min += sd.min;
+                    skill_aggregates[sk].range_max += sd.max;
+                });
+            } else {
+                console.error(entry);
+            }
+        });
 
-		const numSlots = STTApi.playerData.character.voyage_descriptions[0].crew_slots.length;
-		for (let s=0; s<numSlots; ++s) {
-			if (!crewSpans[s]) {
-				let trait = STTApi.playerData.character.voyage_descriptions[0].crew_slots[s].trait;
-				let traitDisp = STTApi.getTraitName(trait);
-				crewSpans[s] = <Card key={s} color={'red'}>
-					<Card.Content>
-						<Card.Header>{}</Card.Header>
-						<Card.Meta>
-							{STTApi.playerData.character.voyage_descriptions[0].crew_slots[s].name}<br />
-							{traitDisp}
-						</Card.Meta>
-						<Card.Description>
-						</Card.Description>
-					</Card.Content>
-					<Card.Content extra>
-						Status: Open <Button onClick={() => setSelectSlotId(selectSlotId !== undefined ? undefined : s) } style={{ float: 'right' }} content='Select' />
-					</Card.Content>
-				</Card>
-			}
-		}
+        const numSlots = STTApi.playerData.character.voyage_descriptions[0].crew_slots.length;
+        for (let s=0; s<numSlots; ++s) {
+            if (!crewSpans[s]) {
+                let trait = STTApi.playerData.character.voyage_descriptions[0].crew_slots[s].trait;
+                let traitDisp = STTApi.getTraitName(trait);
+                crewSpans[s] = <Card key={s} color={'red'}>
+                    <Card.Content>
+                        <Card.Header>{}</Card.Header>
+                        <Card.Meta>
+                            {STTApi.playerData.character.voyage_descriptions[0].crew_slots[s].name}<br />
+                            {traitDisp}
+                        </Card.Meta>
+                        <Card.Description>
+                        </Card.Description>
+                    </Card.Content>
+                    <Card.Content extra>
+                        Status: Open <Button onClick={() => setSelectSlotId(selectSlotId !== undefined ? undefined : s) } style={{ float: 'right' }} content='Select' />
+                    </Card.Content>
+                </Card>
+            }
+        }
 
-		const primarySecondaryOutput = (sk: Skill) => {
-			let isPri = sk.skill === STTApi.playerData.character.voyage_descriptions[0].skills.primary_skill;
-			let isSec = sk.skill === STTApi.playerData.character.voyage_descriptions[0].skills.secondary_skill;
-			return (
-				<span>{isPri ? 'Primary' : isSec ? 'Secondary' : ''}</span>
-			)
-		};
-		const failOutput = (sk: Skill) => {
-			const sv = sk.core + (sk.range_min + sk.range_max) / 2;
-			const failSeconds = (sv * 0.045 + 34) * 60;
-			return (
-				<div>First hazard failure<br/>expected @ {formatTimeSeconds(failSeconds)}</div>
-			)
-		};
-		return <div className='voyage-crew-select'>
-				{props.state === 'inprogress' && <div className='ui medium centered text active inline loader'>Still calculating...</div>}
-				{selectSlotId !== undefined &&
-					<Dropdown
-						fluid
-						selection
-						options={buildOptions(selectSlotId)}
-						onChange={(e, { value }) => setChoice(selectSlotId, value as number)}
-						// value={}
-					/>
-				}
-				<Card.Group>{crewSpans}</Card.Group>
-				{
-					props.crewSelection && props.crewSelection.length &&
-					<VoyageSkillsReadout
-						skill_aggregates={skill_aggregates}
-						success_readout={primarySecondaryOutput}
-						failure_readout={failOutput}
-					/>
-				}
-			</div>;
-	} else {
-		return <span />;
-	}
+        const primarySecondaryOutput = (sk: Skill) => {
+            let isPri = sk.skill === STTApi.playerData.character.voyage_descriptions[0].skills.primary_skill;
+            let isSec = sk.skill === STTApi.playerData.character.voyage_descriptions[0].skills.secondary_skill;
+            return (
+                <span>{isPri ? 'Primary' : isSec ? 'Secondary' : ''}</span>
+            )
+        };
+        const failOutput = (sk: Skill) => {
+            const sv = sk.core + (sk.range_min + sk.range_max) / 2;
+            const failSeconds = (sv * 0.045 + 34) * 60;
+            return (
+                <div>First hazard failure<br/>expected @ {formatTimeSeconds(failSeconds)}</div>
+            )
+        };
+        return <div className='voyage-crew-select'>
+                {props.state === 'inprogress' && <div className='ui medium centered text active inline loader'>Still calculating...</div>}
+                {selectSlotId !== undefined &&
+                    <Dropdown
+                        fluid
+                        selection
+                        options={buildOptions(selectSlotId)}
+                        onChange={(e, { value }) => setChoice(selectSlotId, value as number)}
+                        // value={}
+                    />
+                }
+                <Card.Group>{crewSpans}</Card.Group>
+                {
+                    props.crewSelection.length > 0 &&
+                    <VoyageSkillsReadout
+                        skill_aggregates={skill_aggregates}
+                        success_readout={primarySecondaryOutput}
+                        failure_readout={failOutput}
+                    />
+                }
+            </div>;
+    } else {
+        return <span />;
+    }
 
-	function buildOptions(slotId: number) : DropdownItemProps[] {
-		const slotTrait = STTApi.playerData.character.voyage_descriptions[0].crew_slots[slotId].trait;
-		const slotSkill = STTApi.playerData.character.voyage_descriptions[0].crew_slots[slotId].skill;
-		const available = props.crewAvailable.filter(c => c.skills[slotSkill].voy > 0);
-		return available.sort((a, b) => {
-			const av = Object.keys(CONFIG.SKILLS).map(k => a.skills[k].voy).reduce((acc, c) => acc + c, 0);
-			const bv = Object.keys(CONFIG.SKILLS).map(k => b.skills[k].voy).reduce((acc, c) => acc + c, 0);
-			return bv - av;
-		}).map(c => ({
-			content: <span>{c.name} <CrewSkills crew={c} useIcon={true} asVoyScore={true} addVoyTotal={true} /> {
-				c.rawTraits.find(t => t === slotTrait) ? <b>{slotTrait}</b> : ''}</span>,
-			image: c.iconUrl,
-			value: c.crew_id
-		} as DropdownItemProps));
-	}
+    function buildOptions(slotId: number) : DropdownItemProps[] {
+        const slotTrait = STTApi.playerData.character.voyage_descriptions[0].crew_slots[slotId].trait;
+        const slotSkill = STTApi.playerData.character.voyage_descriptions[0].crew_slots[slotId].skill;
+        const available = props.crewAvailable.filter(c => c.skills[slotSkill].voy > 0);
+        return available.sort((a, b) => {
+            const av = Object.keys(CONFIG.SKILLS).map(k => a.skills[k].voy).reduce((acc, c) => acc + c, 0);
+            const bv = Object.keys(CONFIG.SKILLS).map(k => b.skills[k].voy).reduce((acc, c) => acc + c, 0);
+            return bv - av;
+        }).map(c => ({
+            content: <span>{c.name} <CrewSkills crew={c} useIcon={true} asVoyScore={true} addVoyTotal={true} /> {
+                c.rawTraits.find(t => t === slotTrait) ? <b>{slotTrait}</b> : ''}</span>,
+            image: c.iconUrl,
+            value: c.crew_id
+        } as DropdownItemProps));
+    }
 
-	function setChoice(slotId: number, crewId: number) {
-		let newSelection = props.crewSelection.filter(cc => cc.slotId !== slotId && cc.choice.crew_id !== crewId);
-		newSelection.push({
-			slotId,
-			choice: props.crewAvailable.find(c => c.crew_id === crewId)!
-		});
-		props.crewUpdated(newSelection);
-		setSelectSlotId(undefined);
-	}
+    function setChoice(slotId: number, crewId: number) {
+        let newSelection = props.crewSelection.filter(cc => cc.slotId !== slotId && cc.choice.crew_id !== crewId);
+        newSelection.push({
+            slotId,
+            choice: props.crewAvailable.find(c => c.crew_id === crewId)!
+        });
+        props.crewUpdated(newSelection);
+        setSelectSlotId(undefined);
+    }
 }

--- a/src/components/voyage/VoyageLog.tsx
+++ b/src/components/voyage/VoyageLog.tsx
@@ -133,11 +133,11 @@ export const VoyageLog = (props:{}) => {
          {
             id: 'icon',
             Header: '',
-            minWidth: 72,
-            maxWidth: 72,
+            minWidth: 42,
+            maxWidth: 42,
             resizable: false,
             accessor: (row: any) => row.full_name,
-            Cell: (p: any) => <img className={`image-fit ${spriteClass}`} src={p.original.iconUrl} />
+            Cell: (p: any) => <img className={`image-fit ${spriteClass}`} src={p.original.iconUrl} height='32px' />
          },
          {
             id: 'quantity',

--- a/src/components/voyage/VoyageLog.tsx
+++ b/src/components/voyage/VoyageLog.tsx
@@ -42,6 +42,7 @@ export const VoyageLog = (props:{}) => {
    React.useEffect(() => {
       reloadVoyageState();
    }, []);
+   const spriteClass = GetSpriteCssClass();
 
    if (showSpinner) {
       return (
@@ -61,7 +62,7 @@ export const VoyageLog = (props:{}) => {
       </Button>
    );
 
-   const rewardTableColumns = getColumns();
+   const rewardTableColumns = getColumns(spriteClass);
 
    let voyRunTime = 0;
    if (voyageExport && voyageExport.narrative) {
@@ -110,7 +111,7 @@ export const VoyageLog = (props:{}) => {
             <CollapsibleSection title={"Complete Captain's Log (" + Object.keys(indexedNarrative).length + ')'}>
             {Object.keys(indexedNarrative).map(key => {
                let v = indexedNarrative[+key];
-               return <VoyageLogEntry key={key} log={v} />;
+               return <VoyageLogEntry key={key} log={v} spriteClass={spriteClass} />;
             })}
             </CollapsibleSection>
          }
@@ -126,17 +127,16 @@ export const VoyageLog = (props:{}) => {
          <br />
       </div>;
 
-   function getColumns() {
-      const spriteClass = GetSpriteCssClass();
+   function getColumns(spriteClass: string) {
       return [
          {
             id: 'icon',
             Header: '',
-            minWidth: 30,
-            maxWidth: 30,
+            minWidth: 72,
+            maxWidth: 72,
             resizable: false,
             accessor: (row: any) => row.full_name,
-            Cell: (p: any) => <img className={spriteClass} src={p.original.iconUrl} height={25} />
+            Cell: (p: any) => <img className={`image-fit ${spriteClass}`} src={p.original.iconUrl} />
          },
          {
             id: 'quantity',
@@ -574,7 +574,6 @@ const VoyageState = (props: {
       return <div className='voyage-stats'></div>;
    }
    if (props.voyage.state === 'recalled') {
-      // TODO: FORMAT ME!!!
       return <div className='voyage-stats'>
          <VoyageStat label="Voyage Length" value={formatTimeSeconds(props.voyRunTime)} />
          <VoyageStat label="Time With Recall" value={formatTimeSeconds(props.voyage.voyage_duration)} />

--- a/src/components/voyage/VoyageLogEntry.tsx
+++ b/src/components/voyage/VoyageLogEntry.tsx
@@ -8,11 +8,9 @@ export class VoyageLogEntry extends React.Component<any,any> {
 
       this.props.log.forEach((entry: any) => {
          if (entry.crew) {
-            entry.crewIconUrls = [];
-            for(let i = 0; i < entry.crew.length; i += 1) {
-               let rc = STTApi.roster.find(rosterCrew => rosterCrew.symbol == entry.crew[i]);
-               entry.crewIconUrls.push(rc ? rc.iconUrl ?? '' : '');
-            }
+            entry.crewIconUrls = entry.crew.map((ec: any) =>
+               STTApi.roster.find(rosterCrew => rosterCrew.symbol == ec))
+                  .map((rc: any) => rc ? rc.iconUrl ?? '' : '');
          }
       });
    }
@@ -30,7 +28,7 @@ export class VoyageLogEntry extends React.Component<any,any> {
          }
          let textClass = 'vle-text';
          if (entry.skill_check && (index + 1) === this.props.log.length) {
-            textClass = `${textClass} ui label ${entry.skill_check.passed ? 'green' : 'red'}`
+            textClass = `${textClass} ui header ${entry.skill_check.passed ? 'green' : 'red'}`
             images.push(
                <span key={`skill-${index}`}>
                   <img className={this.props.spriteClass} src={CONFIG.SPRITES['icon_' + entry.skill_check.skill].url} height={32} />

--- a/src/components/voyage/VoyageSkillsReadout.tsx
+++ b/src/components/voyage/VoyageSkillsReadout.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+
+import { CONFIG } from '../../api';
+
+import { GetSpriteCssClass } from '../DarkThemeContext';
+
+export type Skill = {
+    skill: string;
+    core: number;
+    range_min: number;
+    range_max: number;
+};
+
+export const VoyageSkillsReadout = (props: {
+    skill_aggregates: { [sk: string]: Skill };
+    success_readout: (sk: Skill) => JSX.Element;
+    failure_readout: (sk: Skill) => JSX.Element;
+}) => {
+    const spriteClass = GetSpriteCssClass();
+    return (
+        <div className='vc-skills'>
+            <div className='ui label big group-header'>Skill Aggregates</div>
+            {
+                Object.keys(props.skill_aggregates).map(k => props.skill_aggregates[k]).map(skill => {
+                    return (
+                        <div className='vc-skill' key={skill.skill}>
+                            <div className='vcs-icon'>
+                                <img
+                                    className={`image-fit ${spriteClass}`}
+                                    src={CONFIG.SPRITES['icon_' + skill.skill].url}
+                                />
+                            </div>
+                            <div className='vcs-range'>
+                                Core: {skill.core}
+                                <br/>
+                                Range: {skill.range_min}-{skill.range_max}
+                                <br/>
+                                Average: {skill.core + (skill.range_min + skill.range_max) / 2}
+                            </div>
+                            <div className='vcs-success'>
+                                {props.success_readout(skill)}
+                            </div>
+                            <div className='vcs-failure'>
+                                {props.failure_readout(skill)}
+                            </div>
+                        </div>
+                    );
+                })
+            }
+        </div>
+    );
+};

--- a/src/utils/CollapsibleSection.tsx
+++ b/src/utils/CollapsibleSection.tsx
@@ -13,12 +13,19 @@ export const CollapsibleSection = (props:CollapsibleSectionProps) => {
 
 	let background = props.background ? props.background : 'none';
 
-	return (<div>
-		<h2><button type='button'
-			style={{ cursor: 'default', background: background, border: 'none' }}
-			onClick={() => setCollapsed(!isCollapsed)}>
-			<Icon iconName={isCollapsed ? 'ChevronDown' : 'ChevronUp'} className={ColorClassNames.neutralDark} />
-		</button> {props.title}
+	return (<div className='collapsible-section'>
+		<h2>
+			<button
+				type='button'
+				style={{ background: background, border: 'none', marginRight: '6px' }}
+				onClick={() => setCollapsed(!isCollapsed)}
+			>
+				<Icon
+					iconName={isCollapsed ? 'ChevronDown' : 'ChevronUp'}
+					className={ColorClassNames.neutralDark}
+				/>
+			</button>
+			{props.title}
 		</h2>
 		{!isCollapsed && props.children}
 	</div>);


### PR DESCRIPTION
**TLDR**
* Add commas to counters in main header (chron, dil, etc.)
* Facelift for Voyage tab
  * Larger icons
  * Tables instead of lists
  * "Pretty" groups
  * Add dark background to skill icons on light theme

I think I covered all the states of voyages (not started, ongoing, done, etc.), but I'm waiting on my own voyages to see how they react to ensure it looks good for all phases. 

**Longer conversation**
I couldn't see the skill icons when using the light theme (light blue on white). But the dark theme looked decent. So, I wanted to add a dark background to them on light theme. I just took the first screen that had a few of them (aka Voyage tab).

I took a few liberties with the design, so any feedback is appreciated. Especially if you had a vision in mind.

Side conversations (these are widespread, but could be knocked out in other PRs):
* Tabs or 4 spaces for indenting?
  * It isn't consistent
* CRLF vs. LF
  * Looks like Windows and non-Windows folks pitch in here, but do we want to standardize on LF and do some `.gitattributes` to keep it consistent?