### PR TITLE
Bugfix: Mission node canvas not updated when using "Show only unfinished missions"

### DIFF
--- a/src/components/missions/MissionDetails.tsx
+++ b/src/components/missions/MissionDetails.tsx
@@ -20,9 +20,12 @@ interface MissionDetailsState extends IQuestRecommendations {
 
 export class MissionDetails extends React.Component<MissionDetailsProps, MissionDetailsState> {
 	missionDisplay: MissionDisplay | undefined;
+	canvasRef: React.RefObject<HTMLCanvasElement>;
 
 	constructor(props: MissionDetailsProps) {
 		super(props);
+
+		this.canvasRef = React.createRef();
 
 		this.loadMissionDetails = this.loadMissionDetails.bind(this);
 		this.loadMissionDetailsInternal = this.loadMissionDetailsInternal.bind(this);
@@ -46,7 +49,15 @@ export class MissionDetails extends React.Component<MissionDetailsProps, Mission
 		}
 	}
 
-	componentDidUpdate(_prevProps: MissionDetailsProps, prevState: MissionDetailsState) {
+	componentDidUpdate(prevProps: MissionDetailsProps, prevState: MissionDetailsState) {
+		if (this.props.questId !== prevProps.questId) {
+			if (this.props.questId && this.props.questId.data) {
+				this.loadMissionDetails(this.props.questId.data.questId);
+			}
+			else {
+				this.loadMissionDetails(-1);
+			}
+		}
 		if ((this.state.mission !== prevState.mission)
 			|| (this.state.masteryIndex !== prevState.masteryIndex)){
 			this.setState({ selectedChallenge: undefined });
@@ -64,8 +75,9 @@ export class MissionDetails extends React.Component<MissionDetailsProps, Mission
 	}
 
 	updateGraph() {
-		if (!this.refs.canvasMission)
+		if (!this.canvasRef.current) {
 			return;
+		}
 
 		let mission = this.state.mission;
 		if (mission) {
@@ -82,7 +94,7 @@ export class MissionDetails extends React.Component<MissionDetailsProps, Mission
 				this.missionDisplay.reset(maxX, maxY);
 			} else {
 				this.missionDisplay = new MissionDisplay(
-					this.refs.canvasMission, maxX, maxY,
+					this.canvasRef.current, maxX, maxY,
 					(id?: number) => this.setState({ selectedChallenge: id })
 				);
 			}
@@ -453,7 +465,7 @@ export class MissionDetails extends React.Component<MissionDetailsProps, Mission
 				</div>
 				<div className='mission-graph'>
 					<canvas
-						ref='canvasMission'
+						ref={this.canvasRef}
 						width={1000}
 						height={450}
 						style={{ width: '100%', height: 'auto' }}

--- a/src/components/missions/MissionDetails.tsx
+++ b/src/components/missions/MissionDetails.tsx
@@ -57,12 +57,15 @@ export class MissionDetails extends React.Component<MissionDetailsProps, Mission
 			else {
 				this.loadMissionDetails(-1);
 			}
+			this.updateGraph();
 		}
 		if ((this.state.mission !== prevState.mission)
 			|| (this.state.masteryIndex !== prevState.masteryIndex)){
 			this.setState({ selectedChallenge: undefined });
-			this.renderChallengeDetails();
 			this.updateGraph();
+		}
+		if (this.state.selectedChallenge !== prevState.selectedChallenge) {
+			this.missionDisplay?.invalidate();
 		}
 	}
 
@@ -91,7 +94,7 @@ export class MissionDetails extends React.Component<MissionDetailsProps, Mission
 			maxX++; maxY++;
 
 			if (this.missionDisplay) {
-				this.missionDisplay.reset(maxX, maxY);
+				this.missionDisplay.reset(maxX, maxY, this.canvasRef.current);
 			} else {
 				this.missionDisplay = new MissionDisplay(
 					this.canvasRef.current, maxX, maxY,
@@ -129,6 +132,7 @@ export class MissionDetails extends React.Component<MissionDetailsProps, Mission
 						challenge.name);
 				}
 			});
+			this.missionDisplay.invalidate();
 		}
 	}
 

--- a/src/components/missions/MissionExplorer.tsx
+++ b/src/components/missions/MissionExplorer.tsx
@@ -27,13 +27,10 @@ interface MissionOptions extends IDropdownOption {
 }
 
 export class MissionExplorer extends React.Component<MissionExplorerProps, MissionExplorerState> {
-	missionDetailsRef: React.RefObject<MissionDetails>;
-
 	constructor(props: MissionExplorerProps) {
 		super(props);
 
 		this.loadOptions = this.loadOptions.bind(this);
-		this.missionDetailsRef = React.createRef<MissionDetails>();
 
 		this.state = {
 			dataAvailable: true,
@@ -45,6 +42,14 @@ export class MissionExplorer extends React.Component<MissionExplorerProps, Missi
 
 	componentDidMount() {
 		this._updateCommandItems();
+	}
+
+	componentDidUpdate(_prevProps: MissionExplorerProps, prevState: MissionExplorerState) {
+		if (this.state.options.length !== prevState.options.length) {
+			if (!this.state.options.find(opt => opt.key === this.state.selectedItem?.key)) {
+				this.setState({ selectedItem: undefined });
+			}
+		}
 	}
 
 	_updateCommandItems() {
@@ -60,10 +65,10 @@ export class MissionExplorer extends React.Component<MissionExplorerProps, Missi
 						canCheck: true,
 						isChecked: this.state.onlyIncomplete,
 						onClick: () => {
-							let isChecked = !this.state.onlyIncomplete;
+							const isChecked = !this.state.onlyIncomplete;
 							this.setState({
 								options: this.loadOptions(isChecked),
-								onlyIncomplete: isChecked
+								onlyIncomplete: isChecked,
 							}, () => { this._updateCommandItems(); });
 						}
 					}]
@@ -169,9 +174,6 @@ export class MissionExplorer extends React.Component<MissionExplorerProps, Missi
 							selectedKey={this.state.selectedItem?.key}
 							onChange={(_evt, item) => {
 								this.setState({ selectedItem: item });
-								if (this.missionDetailsRef.current && item && item.data) {
-									this.missionDetailsRef.current.loadMissionDetails(item.data.questId);
-								}
 							}}
 							onRenderTitle={this._onRenderTitle}
 							placeholder='Select a mission'
@@ -181,8 +183,7 @@ export class MissionExplorer extends React.Component<MissionExplorerProps, Missi
 					</div>
 					<div className='mission-content'>
 						<MissionDetails
-							questId={this.state.selectedItem}
-							ref={this.missionDetailsRef} />
+							questId={this.state.selectedItem} />
 					</div>
 				</div>
 			);


### PR DESCRIPTION
Steps to Reproduce (before this PR):

1. View Missions page
2. Select a Mission you've already completed AllTheThings
3. Change Setting to Show only unfinished missions
     * Notice Mission dropdown goes back to "Select a mission"
4. Select one of your unfinished missions from the dropdown
    * Notice that mission details are shown, but canvas of mission nodes is missing

This PR addresses this bug and also:
* Remove unnecessary references
* Fixes redraw loop (that used `setInterval` to perpetually redrew the screen) 